### PR TITLE
select adaptive width for process bar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/.vscode
+/build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.10)
+
+project(cpptqdm)
+
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_BUILD_TYPE "Release")
+
+add_executable(${PROJECT_NAME} ${CMAKE_CURRENT_SOURCE_DIR}/test.cpp)
+
+target_include_directories(
+        ${PROJECT_NAME} PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)


### PR DESCRIPTION
+ Add `.gitignore` and `CMakeLists.txt` files.
+ Select `adaptive width` for the process bar. when the width of the output message is larger than the width of the terminal, the message line can not be flushed. This can be solved by selecting a suitable width of the the process bar at the beginning (the origin width is 40).
+ The `adaptive width` module works well on both `ubuntu` and `windows`.

```cpp
        int width = []() {
#ifdef __linux__
          struct winsize win {};
          ioctl(0, TIOCGWINSZ, &win);
          unsigned short width = win.ws_col;
#else
          CONSOLE_SCREEN_BUFFER_INFO csbi;
          GetConsoleScreenBufferInfo(GetStdHandle(STD_OUTPUT_HANDLE), &csbi);
          unsigned short width = csbi.srWindow.Right - csbi.srWindow.Left;
#endif
          // return the space left for process bar 
          // '60' is an experience value to exclude other output info, such as percent, time elapsed, etc.
          return std::max((int)width - 60, 1);
        }();
```
![fig1](https://github.com/aminnj/cpptqdm/assets/76953144/9065fa54-a025-40ae-8e48-1042b198f9fb)
